### PR TITLE
chore: script logic improvement

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - RELEASE_VERSION: 1.0.0
+  - RELEASE_VERSION: 1.0.1
 
 workflows:
   test:

--- a/main.mjs
+++ b/main.mjs
@@ -26,23 +26,16 @@ let sections = {
 
 async function fetchCommits() {
     let numTags = await quiet($`git tag -l | wc -l`)
-    console.log("Number of tags: ", numTags)
     if(manualPreviousCommit) {
-        console.log("Falling to manual commits")
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${manualPreviousCommit}..`)
         return output.stdout.split('\n')
     } else if(numTags > 1) {
         let latest_tag_commit = await quiet($`git rev-list --tags --skip=0 --max-count=1`)
         let latest_tag = await quiet($`git describe --abbrev=0 --tags ${latest_tag_commit}`)
-        console.log("latest tag commit: ", latest_tag_commit)
-        console.log("latest tag: ", latest_tag)
         let previous_tag_commit = await quiet($`git rev-list --tags --skip=1 --max-count=1`)
         let previous_tag = await quiet($`git describe --abbrev=0 --tags ${previous_tag_commit}`)
-        console.log("previous tag commit: ", previous_tag_commit)
-        console.log("previous tag: ", previous_tag)
 
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${latest_tag}...${previous_tag}`)
-        console.log("Output command: ", $`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${latest_tag}...${previous_tag}`)
         return output.stdout.split('\n')
     } else {
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat}`)

--- a/main.mjs
+++ b/main.mjs
@@ -25,17 +25,23 @@ let sections = {
 }
 
 async function fetchCommits() {
+    console.log("Number of tags: ", numTags)
     if(manualPreviousCommit) {
+        console.log("Falling to manual commits")
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${manualPreviousCommit}..`)
         return output.stdout.split('\n')
     } else if(numTags > 1) {
         let latest_tag_commit = await quiet($`git rev-list --tags --skip=0 --max-count=1`)
         let latest_tag = await quiet($`git describe --abbrev=0 --tags ${latest_tag_commit}`)
-        
+        console.log("latest tag commit: ", latest_tag_commit)
+        console.log("latest tag: ", latest_tag)
         let previous_tag_commit = await quiet($`git rev-list --tags --skip=1 --max-count=1`)
         let previous_tag = await quiet($`git describe --abbrev=0 --tags ${previous_tag_commit}`)
+        console.log("previous tag commit: ", previous_tag_commit)
+        console.log("previous tag: ", previous_tag)
 
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${latest_tag}...${previous_tag}`)
+        console.log("Output command: ", $`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat} ${latest_tag}...${previous_tag}`)
         return output.stdout.split('\n')
     } else {
         let output = await quiet($`git log --no-merges --pretty=format:${prettygitformat} --date=format:${dateformat}`)

--- a/main.mjs
+++ b/main.mjs
@@ -228,7 +228,7 @@ async function fetchHistory() {
     try {
       await nothrow($`git fetch --unshallow`)
     } catch(e) {
-      console.log('Failed fetching tags...')
+      console.log('Failed fetching history...')
       console.log(e.toString())
     }
   }

--- a/step.yml
+++ b/step.yml
@@ -97,6 +97,13 @@ inputs:
     summary: |
       Instead of detecting tags, use this commit hash as the starting point of the changelog
       up until current commit
+- custom_branch_name: "develop"
+  opts:
+    is_expand: false
+    is_required: false
+    summary: |
+      Instead of fetching history and tags for all branches, use this field to specify a branch to work with. 
+      Leave this field empty to fetch the entire history and all tags.
 - pretty_git_format: "%s (%cn)"
   opts:
     is_expand: false


### PR DESCRIPTION
## Description
We have noticed that in some cases the step doesn't work as it should and outputs wrong changelog. Here is a list of improvements that should fix it:
- Evaluate `numTags` counter after fetching tags from remote.
- In case a repo was cloned with depth = 1, the script will fetch the whole history.
- Introducing `custom_branch_name` parameter. Lets user to set branch name to fetch tags from. If empty, it will fetch all tags.

P. S.
First time using Js 🙃